### PR TITLE
tests: fix tests to match new documentation (#967)

### DIFF
--- a/test/application/use.js
+++ b/test/application/use.js
@@ -78,7 +78,7 @@ describe('app.use(fn)', () => {
   it('should catch thrown errors in non-async functions', () => {
     const app = new Koa();
 
-    app.use(ctx => ctx.throw('Not Found', 404));
+    app.use(ctx => ctx.throw(404, 'Not Found'));
 
     return request(app.listen())
       .get('/')

--- a/test/context/throw.js
+++ b/test/context/throw.js
@@ -38,7 +38,7 @@ describe('ctx.throw(err, status)', () => {
     const error = new Error('test');
 
     try {
-      ctx.throw(error, 422);
+      ctx.throw(422, error);
     } catch (err) {
       assert.equal(err.status, 422);
       assert.equal(err.message, 'test');
@@ -67,7 +67,7 @@ describe('ctx.throw(msg, status)', () => {
     const ctx = context();
 
     try {
-      ctx.throw('name required', 400);
+      ctx.throw(400, 'name required');
     } catch (err) {
       assert.equal(err.message, 'name required');
       assert.equal(err.status, 400);


### PR DESCRIPTION
`npm test` was displaying deprecation warnings.